### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,4 @@ WORKDIR /usr/app
 COPY . .
 RUN npm i
 
-VOLUME /usr/app/config.js
-
 CMD ["node", "SkinPeek.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:latest
+
+WORKDIR /usr/app
+
+COPY . .
+RUN npm i
+
+VOLUME /usr/app/config.js
+
+CMD ["node", "SkinPeek.js"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ Deploying in the guild happens instantly but the commands can only be used in th
 
 The bot should have role that allows it to send messages and create custom emojis.
 
+### Docker
+
+- [Create a discord bot](https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot) and [add it to your server](https://discordjs.guide/preparations/adding-your-bot-to-servers.html#bot-invite-links) with the `applications.commands` scope
+- Clone the repo and put your bot token in [config.json](https://github.com/giorgi-o/SkinPeek/blob/master/config.json)
+- use `docker-compose up -d` to start the bot, `docker-compose logs -f` to see the logs and `docker-compose down` to stop it.
+- Send `!deploy guild` or `!deploy global` to deploy the commands.
+
 ## Usage
 
 - Login using `/login`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  bot:
+    build: .
+    volumes:
+      - ./config.json:/usr/app/config.json
+    container_name: skin_peek_bot


### PR DESCRIPTION
[Docker](https://www.docker.com/) allows the user to containerize their applications to make it a lot easier to ship them.

You could consider an GitHub Actions workflow to build the Docker image and push it to the GitHub registry as described [here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry). 
An example workflow would look like [this](https://gist.github.com/warriorzz/ed7ee2060b7a9892b371885c6616b31c).