### PR TITLE
SyntaxError: Identifier 'VAL_COLOR_1' has already been declared

### DIFF
--- a/discord/alerts.js
+++ b/discord/alerts.js
@@ -4,7 +4,6 @@ import {getOffers} from "../valorant/shop.js";
 import {getSkin} from "../valorant/cache.js";
 import {VAL_COLOR_1} from "./embed.js"
 import fs from "fs";
-import {VAL_COLOR_1} from "./embed.js";
 
 let alerts = [];
 


### PR DESCRIPTION
I have no idea how this works, so sry if I did the request twice or so.
Just wanted to let you know of this.


import {VAL_COLOR_1} from "./embed.js"
import fs from "fs";
import {VAL_COLOR_1} from "./embed.js";