### PR TITLE
Update discord emoji permission name

### DIFF
--- a/misc/util.js
+++ b/misc/util.js
@@ -170,7 +170,7 @@ export const removeAlertButton = (id, uuid) => new MessageButton().setCustomId(`
 export const removeAlertActionRow = (id, uuid) => new MessageActionRow().addComponents(removeAlertButton(id, uuid));
 
 // apparently the external emojis in an embed only work if @everyone can use external emojis... probably a bug
-export const externalEmojisAllowed = (channel) => channel.permissionsFor(channel.guild.roles.everyone).has(Permissions.FLAGS.USE_EXTERNAL_EMOJIS);
+export const externalEmojisAllowed = (channel) => channel.permissionsFor(channel.guild.roles.everyone).has(Permissions.FLAGS.MANAGE_EMOJIS_AND_STICKERS);
 export const canCreateEmojis = (guild) => guild.me.permissions.has(Permissions.FLAGS.MANAGE_EMOJIS);
 export const emojiToString = (emoji) => emoji && `<:${emoji.name}:${emoji.id}>`;
 


### PR DESCRIPTION
Was getting the following error with the /shop command. It seems like discord changed the flag name.

```
Fetching shop for .....
/home/pi/SkinPeek/node_modules/discord.js/src/util/BitField.js:152
    throw new RangeError('BITFIELD_INVALID', bit);
          ^

RangeError [BITFIELD_INVALID]: Invalid bitfield flag or number: undefined.
    at Function.resolve (/home/pi/SkinPeek/node_modules/discord.js/src/util/BitField.js:152:11)
    at Permissions.has (/home/pi/SkinPeek/node_modules/discord.js/src/util/BitField.js:44:28)
    at Permissions.has (/home/pi/SkinPeek/node_modules/discord.js/src/util/Permissions.js:54:85)
    at canCreateEmojis (file:///home/pi/SkinPeek/misc/util.js:174:64)
    at createEmoji (file:///home/pi/SkinPeek/discord/emoji.js:41:9)
    at getOrCreateEmoji (file:///home/pi/SkinPeek/discord/emoji.js:33:18)
    at VPEmoji (file:///home/pi/SkinPeek/discord/emoji.js:13:76)
    at Client.<anonymous> (file:///home/pi/SkinPeek/discord/bot.js:350:42)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  [Symbol(code)]: 'BITFIELD_INVALID'
}
```