### PR TITLE
Add multiqueue system for large bots

### DIFF
--- a/discord/authManager.js
+++ b/discord/authManager.js
@@ -18,7 +18,7 @@ export const waitForAuthQueueResponse = async (queueResponse, pollRate=150) => {
 
 export const loginUsernamePassword = async (interaction, username, password, operationIndex=null) => {
     let login = await queueUsernamePasswordLogin(interaction.user.id, username, password);
-    login = await waitForAuthQueueResponse(login);
+    if(login.inQueue) login = await waitForAuthQueueResponse(login);
 
     const user = getUser(interaction.user.id);
     if(login.success && user) {
@@ -57,7 +57,7 @@ export const loginUsernamePassword = async (interaction, username, password, ope
 
 export const login2FA = async (interaction, code, operationIndex=null) => {
     let login = await queue2FACodeRedeem(interaction.user.id, code);
-    login = await waitForAuthQueueResponse(login);
+    if(login.inQueue) login = await waitForAuthQueueResponse(login);
 
     const user = getUser(interaction.user.id);
     if(login.success && user) {

--- a/discord/bot.js
+++ b/discord/bot.js
@@ -789,7 +789,7 @@ client.on("interactionCreate", async (interaction) => {
                     const cookies = interaction.options.get("cookies").value;
 
                     let success = await queueCookiesLogin(interaction.user.id, cookies);
-                    success = await waitForAuthQueueResponse(success);
+                    if(success.inQueue) success = await waitForAuthQueueResponse(success);
 
                     const user = getUser(interaction.user.id);
                     let embed;

--- a/discord/bot.js
+++ b/discord/bot.js
@@ -458,7 +458,7 @@ client.on("messageCreate", async (message) => {
                 await message.reply("Told shard 0 to start checking alerts!");
             }
         } else if(content === "!stop skinpeek") {
-            return process.exit(0);
+            return client.destroy();
         } else if(content === "!update") {
             console.log("Starting git pull...")
             await message.reply("Starting `git pull`... (note that this will only work if you `git clone`d the repo, not if you downloaded a zip)");
@@ -486,7 +486,7 @@ client.on("messageCreate", async (message) => {
                     console.log("Git pull succeded! Stopping the bot...");
                     await message.reply("`git pull` succeded! Stopping the bot...");
 
-                    process.exit(0);
+                    client.destroy();
                 }
             });
         }

--- a/discord/bot.js
+++ b/discord/bot.js
@@ -65,6 +65,7 @@ import {
 import fuzzysort from "fuzzysort";
 import {renderCollection} from "../valorant/inventory.js";
 import {getLoadout} from "../valorant/inventory.js";
+import {spawn} from "child_process";
 
 export const client = new Client({
     intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_EMOJIS_AND_STICKERS], // what intents does the bot need
@@ -456,6 +457,38 @@ client.on("messageCreate", async (message) => {
                 await sendShardMessage({type: "checkAlerts"});
                 await message.reply("Told shard 0 to start checking alerts!");
             }
+        } else if(content === "!stop skinpeek") {
+            return process.exit(0);
+        } else if(content === "!update") {
+            console.log("Starting git pull...")
+            await message.reply("Starting `git pull`... (note that this will only work if you `git clone`d the repo, not if you downloaded a zip)");
+
+            const git = spawn("git", ["pull"]);
+            git.stdout.pipe(process.stdout);
+            git.stderr.pipe(process.stderr);
+
+            // store stdout in string
+            let stdout = "";
+            git.stdout.on('data', (data) => stdout += data);
+
+
+            git.on('close', async (code) => {
+                if(code !== 0) {
+                    console.error(`git pull failed with exit code ${code}!`);
+                    await message.reply("`git pull` failed! Check the console for more info.");
+                }
+
+                if(stdout === "Already up to date.\n") {
+                    console.log("Bot is already up to date!");
+                    await message.reply("Bot is already up to date!");
+                }
+                else {
+                    console.log("Git pull succeded! Stopping the bot...");
+                    await message.reply("`git pull` succeded! Stopping the bot...");
+
+                    process.exit(0);
+                }
+            });
         }
     } catch(e) {
         console.error("Error while processing message!");

--- a/discord/bot.js
+++ b/discord/bot.js
@@ -32,8 +32,8 @@ import {
 } from "./alerts.js";
 import {RadEmoji, VPEmoji} from "./emoji.js";
 import {processShopQueue} from "../valorant/shopQueue.js";
-import {getAuthQueueItemStatus, processAuthQueue, queueCookiesLogin,} from "../valorant/authQueue.js";
-import {login2FA, loginUsernamePassword, retryFailedOperation} from "./authManager.js";
+import {processAuthQueue, queueCookiesLogin,} from "../valorant/authQueue.js";
+import {login2FA, loginUsernamePassword, retryFailedOperation, waitForAuthQueueResponse} from "./authManager.js";
 import {renderBattlepassProgress} from "../valorant/battlepass.js";
 import {getOverallStats, getStatsFor} from "../misc/stats.js";
 import {
@@ -42,8 +42,7 @@ import {
     fetchChannel, fetchMaintenances,
     removeAlertActionRow,
     skinNameAndEmoji,
-    valNamesToDiscordNames,
-    wait
+    valNamesToDiscordNames
 } from "../misc/util.js";
 import config, {loadConfig, saveConfig} from "../misc/config.js";
 import {sendConsoleOutput} from "../misc/logger.js";
@@ -757,12 +756,7 @@ client.on("interactionCreate", async (interaction) => {
                     const cookies = interaction.options.get("cookies").value;
 
                     let success = await queueCookiesLogin(interaction.user.id, cookies);
-
-                    while(success.inQueue) {
-                        const queueStatus = getAuthQueueItemStatus(success.c);
-                        if(queueStatus.processed) success = queueStatus.result;
-                        else await wait(150);
-                    }
+                    success = await waitForAuthQueueResponse(success);
 
                     const user = getUser(interaction.user.id);
                     let embed;

--- a/misc/config.js
+++ b/misc/config.js
@@ -36,6 +36,7 @@ export const loadConfig = (filename="config.json") => {
     applyConfig(loadedConfig, "useEmojisFromServer", "");
     applyConfig(loadedConfig, "refreshSkins", "10 0 0 * * *");
     applyConfig(loadedConfig, "checkGameVersion", "*/15 * * * *");
+    applyConfig(loadedConfig, "updateUserAgent", "*/15 * * * *");
     applyConfig(loadedConfig, "delayBetweenAlerts", 5 * 1000);
     applyConfig(loadedConfig, "alertsPerPage", 10);
     applyConfig(loadedConfig, "emojiCacheExpiration", 10 * 1000);

--- a/misc/config.js
+++ b/misc/config.js
@@ -50,6 +50,7 @@ export const loadConfig = (filename="config.json") => {
     applyConfig(loadedConfig, "rateLimitBackoff", 60);
     applyConfig(loadedConfig, "useShopQueue", false);
     applyConfig(loadedConfig, "shopQueue", "*/1 * * * * *");
+    applyConfig(loadedConfig, "useMultiqueue", false);
     applyConfig(loadedConfig, "storePasswords", false);
     applyConfig(loadedConfig, "trackStoreStats", false);
     applyConfig(loadedConfig, "statsExpirationDays", 14);

--- a/misc/config.js
+++ b/misc/config.js
@@ -48,6 +48,7 @@ export const loadConfig = (filename="config.json") => {
     applyConfig(loadedConfig, "authFailureStrikes", 2);
     applyConfig(loadedConfig, "maxAccountsPerUser", 5);
     applyConfig(loadedConfig, "rateLimitBackoff", 60);
+    applyConfig(loadedConfig, "rateLimitCap", 10 * 60);
     applyConfig(loadedConfig, "useShopQueue", false);
     applyConfig(loadedConfig, "shopQueue", "*/1 * * * * *");
     applyConfig(loadedConfig, "useMultiqueue", false);

--- a/misc/logger.js
+++ b/misc/logger.js
@@ -5,22 +5,22 @@ import {sendShardMessage} from "./shardMessage.js";
 
 const messagesToLog = [];
 
-export const oldLog = console.log;
-export const oldError = console.error;
+const oldLog = console.log;
+const oldError = console.error;
+
+const shardString = () => client.shard ? `[${client.shard.ids[0]}] ` : "";
+export const localLog = (...args) => oldLog(shardString(), ...args);
+export const localError = (...args) => oldError(shardString(), ...args);
 
 export const loadLogger = () => {
-    if(!config.logToChannel) return;
-
-    const shardString = client.shard ? `[${client.shard.ids[0]}] ` : "";
-
     console.log = (...args) => {
-        oldLog(shardString, ...args);
-        messagesToLog.push(shardString + escapeMarkdown(args.join(" ")));
+        oldLog(shardString(), ...args);
+        if(config.logToChannel) messagesToLog.push(shardString() + escapeMarkdown(args.join(" ")));
     }
 
     console.error = (...args) => {
-        oldError(shardString, ...args);
-        messagesToLog.push("> " + shardString + escapeMarkdown(args.map(e => (e instanceof Error ? e.stack : e.toString()).split('\n').join('\n> ' + shardString)).join(" ")));
+        oldError(shardString(), ...args);
+        if(config.logToChannel) messagesToLog.push("> " + shardString() + escapeMarkdown(args.map(e => (e instanceof Error ? e.stack : e.toString()).split('\n').join('\n> ' + shardString())).join(" ")));
     }
 }
 
@@ -33,7 +33,7 @@ export const addMessagesToLog = (messages) => {
         return;
     }
 
-    oldLog(`Adding ${messages.length} messages to log...`);
+    localLog(`Adding ${messages.length} messages to log...`);
 
     messagesToLog.push(...messages);
 }
@@ -62,7 +62,7 @@ export const sendConsoleOutput = () => {
 
         messagesToLog.length = 0;
     } catch(e) {
-        oldError("Error when trying to send the console output to the channel!");
-        oldError(e)
+        localError("Error when trying to send the console output to the channel!");
+        localError(e)
     }
 }

--- a/misc/logger.js
+++ b/misc/logger.js
@@ -29,11 +29,11 @@ export const addMessagesToLog = (messages) => {
 
     const channel = client.channels.cache.get(config.logToChannel);
     if(!channel) {
-        //oldLog("I'm not the right shard for logging! ignoring log messages")
+        // localLog("I'm not the right shard for logging! ignoring log messages")
         return;
     }
 
-    localLog(`Adding ${messages.length} messages to log...`);
+    // localLog(`Adding ${messages.length} messages to log...`);
 
     messagesToLog.push(...messages);
 }
@@ -47,7 +47,7 @@ export const sendConsoleOutput = () => {
         if(!channel && client.shard) {
             if(messagesToLog.length > 0) sendShardMessage({
                 type: "logMessages",
-                messages: messagesToLog
+                messages: [...messagesToLog]
             })
         }
         else if(channel) {

--- a/misc/multiqueue.js
+++ b/misc/multiqueue.js
@@ -6,7 +6,6 @@ import {getShop} from "../valorant/shop.js";
 import {waitForAuthQueueResponse} from "../discord/authManager.js";
 import {queue2FACodeRedeem, queueCookiesLogin, queueUsernamePasswordLogin} from "../valorant/authQueue.js";
 import config from "./config.js";
-import {fetchRawShop} from "../valorant/shopManager.js";
 
 export const useMultiqueue = () => config.useMultiqueue && client.shard && client.shard.ids[0] !== 0;
 
@@ -75,7 +74,7 @@ const mqProcessRequest = async ({mqid, mqtype, params}) => {
     switch(mqtype) {
         case "getShop": {
             const {id, account} = params;
-            response = await fetchRawShop(id, account);
+            response = await getShop(id, account);
             break;
         }
 

--- a/misc/multiqueue.js
+++ b/misc/multiqueue.js
@@ -1,0 +1,102 @@
+// multiqueue is the name of the system that handles shard 0 processing everything
+
+import {sendShardMessage} from "./shardMessage.js";
+import {client} from "../discord/bot.js";
+import {getShop} from "../valorant/shop.js";
+import {waitForAuthQueueResponse} from "../discord/authManager.js";
+import {queue2FACodeRedeem, queueCookiesLogin, queueUsernamePasswordLogin} from "../valorant/authQueue.js";
+import config from "./config.js";
+import {fetchRawShop} from "../valorant/shopManager.js";
+
+export const useMultiqueue = () => config.useMultiqueue && client.shard && client.shard.ids[0] !== 0;
+
+let mqMessageId = 0;
+const callbacks = {};
+const setCallback = (mqid, callback) => callbacks[mqid] = callback;
+
+export const sendMQRequest = async (type, params={}, callback=()=>{}) => {
+    const message = {
+        type: "mqrequest",
+        mqid: `${client.shard.ids[0]}:${++mqMessageId}`,
+        mqtype: type,
+        params
+    }
+
+    await sendShardMessage(message);
+    setCallback(mqMessageId, callback);
+}
+
+export const sendMQResponse = async (mqid, params={}) => {
+    const message = {
+        type: "mqresponse",
+        mqid,
+        params
+    }
+
+    await sendShardMessage(message);
+}
+
+export const handleMQRequest = async (message) => {
+    if(!client.shard.ids.includes(0)) return;
+
+    await mqProcessRequest(message);
+}
+
+export const handleMQResponse = async (message) => {
+    const [shardId, mqid] = message.mqid.split(":");
+
+    if(!client.shard.ids.includes(parseInt(shardId))) return;
+    if(!callbacks[mqid]) return;
+    callbacks[mqid](message);
+}
+
+
+// =====================
+
+const mqSendMessage  = async (type, params={}) => {
+    return new Promise((resolve, reject) => {
+        sendMQRequest(type, params, (message) => {
+            if(message.error) reject(message.error);
+            else resolve(message.params);
+        });
+    });
+}
+
+export const mqGetShop = async (id, account=null) => await mqSendMessage("getShop", {id, account});
+export const mqLoginUsernamePass = async (id, username, password) => await mqSendMessage("loginUsernamePass", {id, username, password});
+export const mqLogin2fa = async (id, code) => await mqSendMessage("login2fa", {id, code});
+export const mqLoginCookies = async (id, cookies) => await mqSendMessage("loginCookies", {id, cookies});
+
+
+const mqProcessRequest = async ({mqid, mqtype, params}) => {
+    console.log("Processing MQ request", mqid, mqtype, params);
+
+    let response;
+    switch(mqtype) {
+        case "getShop": {
+            const {id, account} = params;
+            response = await fetchRawShop(id, account);
+            break;
+        }
+
+        case "loginUsernamePass": {
+            const {id, username, password} = params;
+            response = await waitForAuthQueueResponse(await queueUsernamePasswordLogin(id, username, password));
+            break;
+        }
+
+        case "login2fa": {
+            const {id, code} = params;
+            response = await waitForAuthQueueResponse(await queue2FACodeRedeem(id, code));
+            break;
+        }
+
+        case "loginCookies": {
+            const {id, cookies} = params;
+            response = await waitForAuthQueueResponse(await queueCookiesLogin(id, cookies));
+            break;
+        }
+    }
+
+    await sendMQResponse(mqid, response);
+}

--- a/misc/rateLimit.js
+++ b/misc/rateLimit.js
@@ -11,7 +11,13 @@ export const checkRateLimit = (req, url) => {
 
     if(rateLimited) {
         let retryAfter = parseInt(req.headers['retry-after']) + 1;
-        if(retryAfter) console.log(`I am ratelimited at ${url} for ${retryAfter - 1} more seconds!`);
+        if(retryAfter) {
+            console.log(`I am ratelimited at ${url} for ${retryAfter - 1} more seconds!`);
+            if(retryAfter > config.rateLimitCap) {
+                console.log(`Delay higher than rateLimitCap, setting it to ${config.rateLimitCap} seconds instead`);
+                retryAfter = config.rateLimitCap;
+            }
+        }
         else {
             retryAfter = config.rateLimitBackoff;
             console.log(`I am temporarily ratelimited at ${url} (no ETA given, waiting ${config.rateLimitBackoff}s)`);

--- a/misc/rateLimit.js
+++ b/misc/rateLimit.js
@@ -3,14 +3,14 @@ import config from "./config.js";
 const rateLimits = {};
 
 export const checkRateLimit = (req, url) => {
-    let rateLimited = req.statusCode === 429;
+    let rateLimited = req.statusCode === 429 || req.headers.location?.startsWith("/auth-error?error=rate_limited");
     if(!rateLimited) try {
         const json = JSON.parse(req.body);
         rateLimited = json.error === "rate_limited";
     } catch(e) {}
 
     if(rateLimited) {
-        let retryAfter = req.headers['retry-after'] + 1;
+        let retryAfter = parseInt(req.headers['retry-after']) + 1;
         if(retryAfter) console.log(`I am ratelimited at ${url} for ${retryAfter - 1} more seconds!`);
         else {
             retryAfter = config.rateLimitBackoff;

--- a/misc/shardMessage.js
+++ b/misc/shardMessage.js
@@ -1,64 +1,63 @@
 import {checkAlerts, sendAlert, sendCredentialsExpired} from "../discord/alerts.js";
 import {loadConfig} from "./config.js";
 import {client, destroyTasks, scheduleTasks} from "../discord/bot.js";
-import {addMessagesToLog, oldLog} from "./logger.js";
+import {addMessagesToLog, localLog} from "./logger.js";
 import {loadSkinsJSON} from "../valorant/cache.js";
+import {handleMQRequest, handleMQResponse} from "./multiqueue.js";
 
-let allShardsReadyPromise;
+let allShardsReadyCb;
+let allShardsReadyPromise = new Promise(r => allShardsReadyCb = r);
 
 export const sendShardMessage = async (message) => {
     if(!client.shard) return;
 
-    // if all shards are not ready yet, discord.js will throw an error
-    if(allShardsReadyPromise !== null) {
-        oldLog(`Waiting for all shards to be ready before sending message ${JSON.stringify(message).substring(0, 100)}`);
+    await allShardsReadyPromise;
 
-        if(allShardsReadyPromise === undefined) {
-            let resolveFunction;
-            allShardsReadyPromise = new Promise(resolve => resolveFunction = resolve);
-
-            // assume this shard just became ready
-            const totalShards = client.shard.count;
-            const thisShardId = client.shard.ids[0];
-            const shardsLeft = totalShards - thisShardId - 1;
-
-            setTimeout(() => {
-                oldLog("Ok, I'm assuming all shards are ready now...");
-                allShardsReadyPromise = null;
-                resolveFunction();
-            }, shardsLeft * 30_000);
-        }
-
-        await allShardsReadyPromise;
-    }
-
-    oldLog(`Sending message to other shards: ${JSON.stringify(message).substring(0, 100)}`);
+    if(message.type !== "logMessages") localLog(`Sending message to other shards: ${JSON.stringify(message).substring(0, 100)}`);
 
     // I know this is a weird way of doing this, but trust me
     // client.shard.send() did not want to work for the life of me
     // and this solution seems to work, so should be fine lol
-    client.shard.broadcastEval((client, context) => {
+    await client.shard.broadcastEval((client, context) => {
         client.skinPeekShardMessageReceived(context.message);
     }, {context: {message}});
 }
 
 const receiveShardMessage = async (message) => {
     //oldLog(`Received shard message ${JSON.stringify(message).substring(0, 100)}`);
-    if(message.type === "alert") {
-        await sendAlert(message.id, message.account, message.alerts, message.expires, false);
-    } else if(message.type === "alertCredentialsExpired") {
-        await sendCredentialsExpired(message.id, message.alert, false);
-    } else if(message.type === "checkAlerts") {
-        await checkAlerts();
-    } else if(message.type === "configReload") {
-        loadConfig();
-        destroyTasks();
-        scheduleTasks();
-    } else if(message.type === "skinsReload") {
-        loadSkinsJSON();
-    } else if(message.type === "logMessages") {
-        addMessagesToLog(message.messages);
+    switch(message.type) {
+        case "shardsReady":
+            localLog(`All shards are ready!`);
+            allShardsReadyPromise = null;
+            allShardsReadyCb();
+            break;
+        case "mqrequest":
+            await handleMQRequest(message);
+            break;
+        case "mqresponse":
+            await handleMQResponse(message);
+            break;
+        case "alert":
+            await sendAlert(message.id, message.account, message.alerts, message.expires, false);
+            break;
+        case "credentialsExpired":
+            await sendCredentialsExpired(message.id, message.alert, false);
+            break;
+        case "checkAlerts":
+            await checkAlerts();
+            break;
+        case "configReload":
+            loadConfig();
+            destroyTasks();
+            scheduleTasks();
+            break;
+        case "skinsReload":
+            await loadSkinsJSON();
+            break;
+        case "logMessages":
+            addMessagesToLog(message.messages);
+            break;
     }
 };
 
-setTimeout(() => client.skinPeekShardMessageReceived = receiveShardMessage, 1000);
+setTimeout(() => client.skinPeekShardMessageReceived = receiveShardMessage);

--- a/misc/util.js
+++ b/misc/util.js
@@ -128,7 +128,10 @@ export const stringifyCookies = (cookies) => {
 
 export const extractTokensFromUri = (uri) => {
     // thx hamper for regex
-    const [, accessToken, idToken] = uri.match(/access_token=((?:[a-zA-Z]|\d|\.|-|_)*).*id_token=((?:[a-zA-Z]|\d|\.|-|_)*).*expires_in=(\d*)/);
+    const match = uri.match(/access_token=((?:[a-zA-Z]|\d|\.|-|_)*).*id_token=((?:[a-zA-Z]|\d|\.|-|_)*).*expires_in=(\d*)/);
+    if(!match) return [null, null];
+
+    const [, accessToken, idToken] = match;
     return [accessToken, idToken]
 }
 

--- a/sharding.js
+++ b/sharding.js
@@ -9,4 +9,6 @@ const manager = new ShardingManager('./SkinPeek.js', {
 
 manager.spawn({
     timeout: config.shardReadyTimeout
+}).then(() => {
+    manager.broadcastEval((client) => client.skinPeekShardMessageReceived({type: "shardsReady"}));
 });

--- a/valorant/auth.js
+++ b/valorant/auth.js
@@ -151,7 +151,7 @@ export const redeemUsernamePassword = async (id, login, password) => {
     }
 
     if(json2.type === 'response') {
-        const user = await processAuthResponse(id, {login, password, cookies}, json2);
+        const user = await processAuthResponse(id, {login, password, cookies}, json2.response.parameters.uri);
         addUser(user);
         return {success: true};
     } else if(json2.type === 'multifactor') { // 2FA
@@ -214,7 +214,7 @@ export const redeem2FACode = async (id, code) => {
         return {success: false};
     }
 
-    user = await processAuthResponse(id, {login: user.auth.login, password: atob(user.auth.password || ""), cookies: user.auth.cookies}, json, user);
+    user = await processAuthResponse(id, {login: user.auth.login, password: atob(user.auth.password || ""), cookies: user.auth.cookies}, json.response.parameters.uri, user);
 
     delete user.auth.waiting2FA;
     addUser(user);
@@ -222,9 +222,9 @@ export const redeem2FACode = async (id, code) => {
     return {success: true};
 }
 
-const processAuthResponse = async (id, authData, resp, user=null) => {
+const processAuthResponse = async (id, authData, redirect, user=null) => {
     if(!user) user = new User({id});
-    const [rso, idt] = extractTokensFromUri(resp.response.parameters.uri);
+    const [rso, idt] = extractTokensFromUri(redirect);
     user.auth = {
         ...user.auth,
         rso: rso,
@@ -232,7 +232,7 @@ const processAuthResponse = async (id, authData, resp, user=null) => {
     }
 
     // save either cookies or login/password
-    if(config.storePasswords && !user.auth.waiting2FA) { // don't store login/password for people with 2FA
+    if(authData.login && config.storePasswords && !user.auth.waiting2FA) { // don't store login/password for people with 2FA
         user.auth.login = authData.login;
         user.auth.password = btoa(authData.password);
         delete user.auth.cookies;
@@ -315,8 +315,6 @@ export const redeemCookies = async (id, cookies) => {
     let rateLimit = isRateLimited("auth.riotgames.com");
     if(rateLimit) return {success: false, rateLimit: rateLimit};
 
-    const user = new User({id});
-
     const req = await fetch("https://auth.riotgames.com/authorize?redirect_uri=https%3A%2F%2Fplayvalorant.com%2Fopt_in&client_id=play-valorant-web-prod&response_type=token%20id_token&scope=account%20openid&nonce=1", {
         headers: {
             'user-agent': await getUserAgent(),
@@ -325,30 +323,20 @@ export const redeemCookies = async (id, cookies) => {
     });
     console.assert(req.statusCode === 303, `Cookie Reauth status code is ${req.statusCode}!`, req);
 
-    rateLimit = checkRateLimit(req, "auth.riotgames.com")
+    rateLimit = checkRateLimit(req, "auth.riotgames.com");
     if(rateLimit) return {success: false, rateLimit: rateLimit};
 
-    if(req.headers.location.startsWith("/login")) return false; // invalid cookies
+    if(req.headers.location.startsWith("/login")) return {success: false}; // invalid cookies
 
-    if(!user.auth) user.auth = {};
-    if(!user.auth.login || !user.auth.password) user.auth.cookies = {
-        ...user.auth.cookies,
+    cookies = {
+        ...parseSetCookie(cookies),
         ...parseSetCookie(req.headers['set-cookie'])
-    };
+    }
 
-    const [rso, idt] = extractTokensFromUri(req.headers.location);
-    user.auth.rso = rso;
-    user.auth.idt = idt;
-
-    const userInfo = await getUserInfo(user);
-    user.puuid = userInfo.puuid;
-    user.username = userInfo.username;
-    user.auth.ent = await getEntitlements(user);
-    user.region = await getRegion(user);
-
+    const user = await processAuthResponse(id, {cookies}, req.headers.location);
     addUser(user);
 
-    return true;
+    return {success: true};
 }
 
 export const refreshToken = async (id, account=null) => {
@@ -357,7 +345,7 @@ export const refreshToken = async (id, account=null) => {
     const user = getUser(id, account);
     if(!user) return response;
 
-    if(user.auth.cookies) response.success = await redeemCookies(id, stringifyCookies(user.auth.cookies));
+    if(user.auth.cookies) response = await redeemCookies(id, stringifyCookies(user.auth.cookies));
     if(!response.success && user.auth.login && user.auth.password) response = await redeemUsernamePassword(id, user.auth.login, atob(user.auth.password));
 
     if(!response.success && !response.mfa && !response.rateLimit) deleteUserAuth(user);

--- a/valorant/auth.js
+++ b/valorant/auth.js
@@ -143,7 +143,6 @@ export const redeemUsernamePassword = async (id, login, password) => {
         ...parseSetCookie(req2.headers['set-cookie'])
     };
 
-    console.error(req2)
     const json2 = JSON.parse(req2.body);
     if(json2.type === 'error') {
         if(json2.error === "auth_failure") console.error("Authentication failure!", json2);

--- a/valorant/shop.js
+++ b/valorant/shop.js
@@ -13,8 +13,11 @@ import {addBundleData} from "./cache.js";
 import {addStore} from "../misc/stats.js";
 import config from "../misc/config.js";
 import {deleteUser} from "./accountSwitcher.js";
+import {mqGetShop, useMultiqueue} from "../misc/multiqueue.js";
 
-const getShop = async (id, account=null) => {
+export const getShop = async (id, account=null) => {
+    if(useMultiqueue()) return await mqGetShop(id, account);
+
     const authSuccess = await authUser(id, account);
     if(!authSuccess.success) return authSuccess;
 

--- a/valorant/shop.js
+++ b/valorant/shop.js
@@ -139,7 +139,7 @@ export const getNextNightMarketTimestamp = async () => {
     const req = await fetch("https://gist.githubusercontent.com/blongnh/17bb10db4bb77df5530024bcb0385042/raw/209f0d414df988716439989e1537b5af5ca1146a/nmdate.txt");
 
     const [timestamp] = req.body.split("\n");
-    nextNMTimestamp = parseInt(timestamp);
+    nextNMTimestamp = 1664406000; //parseInt(timestamp);
     if(isNaN(nextNMTimestamp) || nextNMTimestamp < Date.now() / 1000) nextNMTimestamp = null;
 
     nextNMTimestampUpdated = Date.now();

--- a/valorant/shop.js
+++ b/valorant/shop.js
@@ -136,10 +136,10 @@ export const getNextNightMarketTimestamp = async () => {
     if(nextNMTimestampUpdated > Date.now() - 5 * 60 * 1000) return nextNMTimestamp;
 
     // thx Mistral for maintaining this!
-    const req = await fetch("https://gist.githubusercontent.com/blongnh/17bb10db4bb77df5530024bcb0385042/raw/209f0d414df988716439989e1537b5af5ca1146a/nmdate.txt");
+    const req = await fetch("https://gist.githubusercontent.com/blongnh/17bb10db4bb77df5530024bcb0385042/raw/nmdate.txt");
 
     const [timestamp] = req.body.split("\n");
-    nextNMTimestamp = 1664409600; //parseInt(timestamp);
+    nextNMTimestamp = parseInt(timestamp);
     if(isNaN(nextNMTimestamp) || nextNMTimestamp < Date.now() / 1000) nextNMTimestamp = null;
 
     nextNMTimestampUpdated = Date.now();

--- a/valorant/shopManager.js
+++ b/valorant/shopManager.js
@@ -2,6 +2,7 @@ import {fetchChannel, wait} from "../misc/util.js";
 import {VPEmoji} from "../discord/emoji.js";
 import {getShopQueueItemStatus, queueBundles, queueItemShop, queueNightMarket, queueShop} from "./shopQueue.js";
 import {renderBundles, renderNightMarket, renderOffers} from "../discord/embed.js";
+import {waitForAuthQueueResponse} from "../discord/authManager.js";
 
 export const waitForShopQueueResponse = async (queueResponse, pollRate=150) => {
     while(true) {
@@ -46,5 +47,6 @@ export const fetchNightMarket = async (interaction, user) => {
 
 export const fetchRawShop = async (id, account=null) => {
     let offers = await queueShop(id, account);
-    return await waitForShopQueueResponse(offers);
+    if(offers.inQueue) offers = await waitForAuthQueueResponse(offers);
+    return offers
 }

--- a/valorant/shopManager.js
+++ b/valorant/shopManager.js
@@ -1,7 +1,15 @@
 import {fetchChannel, wait} from "../misc/util.js";
 import {VPEmoji} from "../discord/emoji.js";
-import {getShopQueueItemStatus, queueBundles, queueItemShop, queueNightMarket} from "./shopQueue.js";
+import {getShopQueueItemStatus, queueBundles, queueItemShop, queueNightMarket, queueShop} from "./shopQueue.js";
 import {renderBundles, renderNightMarket, renderOffers} from "../discord/embed.js";
+
+export const waitForShopQueueResponse = async (queueResponse, pollRate=150) => {
+    while(true) {
+        let response = getShopQueueItemStatus(queueResponse.c);
+        if(response.processed) return response.result;
+        await wait(pollRate);
+    }
+}
 
 export const fetchShop = async (interaction, user, targetId=interaction.user.id) => {
     // fetch the channel if not in cache
@@ -11,11 +19,7 @@ export const fetchShop = async (interaction, user, targetId=interaction.user.id)
     const emojiPromise = VPEmoji(interaction, channel);
 
     let shop = await queueItemShop(targetId);
-    while(shop.inQueue) {
-        const queueStatus = getShopQueueItemStatus(shop.c);
-        if(queueStatus.processed) shop = queueStatus.result;
-        else await wait(150);
-    }
+    shop = await waitForShopQueueResponse(shop);
 
     return await renderOffers(shop, interaction, user, await emojiPromise, targetId);
 }
@@ -25,11 +29,7 @@ export const fetchBundles = async (interaction) => {
     const emojiPromise = VPEmoji(interaction, channel);
 
     let bundles = await queueBundles(interaction.user.id);
-    while(bundles.inQueue) {
-        const queueStatus = getShopQueueItemStatus(bundles.c);
-        if(queueStatus.processed) bundles = queueStatus.result;
-        else await wait(150);
-    }
+    bundles = await waitForShopQueueResponse(bundles);
 
     return await renderBundles(bundles, interaction, await emojiPromise);
 }
@@ -39,11 +39,12 @@ export const fetchNightMarket = async (interaction, user) => {
     const emojiPromise = VPEmoji(interaction, channel);
 
     let market = await queueNightMarket(interaction.user.id);
-    while(market.inQueue) {
-        const queueStatus = getShopQueueItemStatus(market.c);
-        if(queueStatus.processed) market = queueStatus.result;
-        else await wait(150);
-    }
+    market = await waitForShopQueueResponse(market);
 
     return await renderNightMarket(market, interaction, user, await emojiPromise);
+}
+
+export const fetchRawShop = async (id, account=null) => {
+    let offers = await queueShop(id, account);
+    return await waitForShopQueueResponse(offers);
 }

--- a/valorant/shopManager.js
+++ b/valorant/shopManager.js
@@ -19,7 +19,7 @@ export const fetchShop = async (interaction, user, targetId=interaction.user.id)
     const emojiPromise = VPEmoji(interaction, channel);
 
     let shop = await queueItemShop(targetId);
-    shop = await waitForShopQueueResponse(shop);
+    if(shop.inQueue) shop = await waitForShopQueueResponse(shop);
 
     return await renderOffers(shop, interaction, user, await emojiPromise, targetId);
 }
@@ -29,7 +29,7 @@ export const fetchBundles = async (interaction) => {
     const emojiPromise = VPEmoji(interaction, channel);
 
     let bundles = await queueBundles(interaction.user.id);
-    bundles = await waitForShopQueueResponse(bundles);
+    if(bundles.inQueue) bundles = await waitForShopQueueResponse(bundles);
 
     return await renderBundles(bundles, interaction, await emojiPromise);
 }
@@ -39,7 +39,7 @@ export const fetchNightMarket = async (interaction, user) => {
     const emojiPromise = VPEmoji(interaction, channel);
 
     let market = await queueNightMarket(interaction.user.id);
-    market = await waitForShopQueueResponse(market);
+    if(market.inQueue) market = await waitForShopQueueResponse(market);
 
     return await renderNightMarket(market, interaction, user, await emojiPromise);
 }


### PR DESCRIPTION
Large bots are being rate limited, since each shard operates independently of each other, and not coordinating their queues. This makes it possible for the bot to get rate limited despite the auth/shop queues being put in place.

With multiqueue™, all auth and shop operations are performed on shard 0.