### PR TITLE
Fix maxEmoji condition not creating emojis correctly

### DIFF
--- a/discord/emoji.js
+++ b/discord/emoji.js
@@ -72,7 +72,7 @@ const createEmoji = async (guild, name, filenameOrUrl) => {
     if(!canCreateEmojis(guild)) return console.log(`Don't have permission to create emoji ${name} in guild ${guild.name}!`);
 
     await updateEmojiCache(guild);
-    if(guild.emojis.cache.size >= maxEmojis(guild))
+    if(guild.emojis.cache.filter(e => !e.animated).size >= maxEmojis(guild))
         return console.log(`Emoji limit of ${maxEmojis(guild)} reached for ${guild.name} while uploading ${name}!`);
 
     console.log(`Uploading emoji ${name} in ${guild.name}...`);


### PR DESCRIPTION
The current code only checks for the actual size of the GuildEmoji cache, which takes in account both static & animated emotes
But, the actual limit is set by, for exemple at level 1 boosting, 100 emotes max *per type*

This fixes the issue by checking only the number of static emotes in the guild